### PR TITLE
Dsl precommit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: trino-acl-dsl-check
+  name: Trino ACL DSL Check
+  description: Verify that rules DSL yaml file is consistent with a corresponding rules.json file
+  entry: trino-acl-dsl-check
+  language: python
+  types: [yaml]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ A declarative format for configuring Trino access control
 
 To operationalize this code you need Trino adminstrator privileges
 
-### example:
+### examples:
+
+#### Converting Trino ACL DSL to a rules.json
 ```sh
 # install package using pipenv, pip or similar tools
 $ pipenv install osc-trino-acl-dsl
@@ -26,3 +28,28 @@ $ head rules.json
             "catalog": "dev",
             "allow": "all"
 ```
+
+#### Using pre-commit checks
+For more information on pre-commit checks, see [here](https://pre-commit.com/)
+
+Here is an example entry for `.pre-commit-config.yaml`
+```yaml
+repos:
+  - repo: https://github.com/os-climate/osc-trino-acl-dsl
+    rev: v0.2.0
+    hooks:
+      # a pre-commit check to verify that an ACL DSL yaml file is in sync with rules.json file
+      - id: trino-acl-dsl-check
+        # by default, check pattern matches files named 'trino-acl-dsl.yaml'
+        # args: [ '--check-pattern=^my-file-regex\.yaml$' ]
+```
+
+### building and testing
+
+#### iterative dev/test for pre-commit checks
+
+1. check out this repository
+1. make some change to precommit checks you want to test
+1. in a test repository, make an edit you expect your precommit check to operate on, then `git add` this edit (i.e. stage it for commit) but do NOT commit it, so the precommit check sees it and properly provides staged files to the argument list.
+1. run `pre-commit try-repo /path/to/osc-trino-acl-dsl --verbose` (see [here](https://pre-commit.com/#pre-commit-try-repo))
+1. examine the output of your precommit check to see if it did what you want

--- a/osc_trino_acl_dsl/rules_precommit_check.py
+++ b/osc_trino_acl_dsl/rules_precommit_check.py
@@ -1,0 +1,73 @@
+import sys
+import os
+import json
+import argparse
+import re
+
+import yaml  # via pyyaml module
+
+import jsonschema
+
+from .dsl2rules import dsl_to_rules
+from .__init__ import __version__
+
+_out_of_sync_message = """{prog}: {jsonfile} out of sync with {dslfile}
+
+suggested steps to fix your commit:
+$ pip install --user osc-trino-acl-dsl=={version}
+$ trino-dsl-to-rules {dslfile} > {jsonfile}
+$ git add {jsonfile}
+"""
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('paths', metavar='CHECK_FILES', nargs='*',
+        help='files to check, normally files staged for git commit')
+    parser.add_argument('--check-pattern', metavar='CHECK_PATTERN',
+        help='check only files that match this regular expression',
+        default='^trino-acl-dsl\.yaml$')
+
+    # parse command line args
+    args = parser.parse_args(sys.argv[1:]) # argv[0] is command
+
+    # precompile our regular expression that defines which files to check
+    print(f"{parser.prog}: checking files matching regex '{args.check_pattern}'")
+    checkre = re.compile(args.check_pattern)
+
+    for pname in args.paths:
+        dname, fname = os.path.split(pname)
+        if not checkre.match(fname):
+            print(f"{parser.prog}: ignoring {pname}")
+            continue
+        print(f"{parser.prog}: checking {pname}")
+        rulespath = os.path.join(dname, "rules.json")
+        if not os.path.isfile(rulespath):
+            # I expect a rules.json file for any file that matches the pattern
+            print(f"{parser.prog}: did not find expected file {rulespath}")
+            sys.exit(1)
+        print(f"{parser.prog}: checking consistency with {rulespath}")
+        try:
+            # load the dsl yaml and convert it to rules.json format
+            with open(pname, 'r') as dsl_file:
+                dsl = yaml.safe_load(dsl_file)
+            with open(rulespath, 'r') as json_file:
+                jsonrules = json.load(json_file)
+            dslrules = dsl_to_rules(dsl, validate = True)
+            if not (jsonrules == dslrules):
+                print(_out_of_sync_message.format(
+                    prog = parser.prog,
+                    jsonfile = rulespath,
+                    dslfile = pname,
+                    version = __version__))
+                sys.exit(1)
+        except Exception as e:
+            # any exception is a test failure
+            print(f"{parser.prog}: commit check failed with exception {type(e)}:\n{e}")
+            sys.exit(1)
+        # all checks passed for current file
+        print(f"{parser.prog}: check succeeded for {pname}")
+    # all checks passed for any matching files, exit with 'success'
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     entry_points = {
         "console_scripts": [
             "trino-dsl-to-rules=osc_trino_acl_dsl.dsl2rules:main",
+            "trino-acl-dsl-check=osc_trino_acl_dsl.rules_precommit_check:main",
         ],
     },
 )


### PR DESCRIPTION
A pre-commit hook that could be used with `operate-first/apps` and enforce that DSL files are properly synced with `rules.json` prior to commits.

This approach allows the current trino configuration system to remain in place, but instead maintain a dsl.yaml file that is kept in sync with corresponding rules.json using `trino-dsl-to-rules` module command.

cc @HumairAK @harshad16 